### PR TITLE
style: apply rustfmt to codebase

### DIFF
--- a/crates/soroban-rs/src/account.rs
+++ b/crates/soroban-rs/src/account.rs
@@ -9,34 +9,34 @@ impl<'a> AccountManager<'a> {
     pub fn new(provider: &'a Provider, signer: &'a Signer) -> Self {
         Self { provider, signer }
     }
-    
+
     pub async fn get_sequence(&self) -> Result<i64, Box<dyn std::error::Error>> {
         let account_id = self.signer.account_id().clone();
         let account_details = self.provider.get_account(&account_id.to_string()).await?;
         Ok(account_details.seq_num.into())
     }
-    
+
     pub fn account_id(&self) -> stellar_xdr::curr::AccountId {
         self.signer.account_id()
     }
-    
+
     pub fn sign_transaction(
-        &self, 
-        tx: &stellar_xdr::curr::Transaction
+        &self,
+        tx: &stellar_xdr::curr::Transaction,
     ) -> Result<stellar_xdr::curr::TransactionEnvelope, Box<dyn std::error::Error>> {
         self.signer.sign_transaction(tx, self.provider.network_id())
     }
-    
+
     pub async fn send_transaction(
         &self,
-        tx_envelope: &stellar_xdr::curr::TransactionEnvelope
+        tx_envelope: &stellar_xdr::curr::TransactionEnvelope,
     ) -> Result<stellar_rpc_client::GetTransactionResponse, Box<dyn std::error::Error>> {
         Ok(self.provider.send_transaction(tx_envelope).await?)
     }
-    
+
     pub async fn simulate_transaction(
         &self,
-        tx_envelope: &stellar_xdr::curr::TransactionEnvelope
+        tx_envelope: &stellar_xdr::curr::TransactionEnvelope,
     ) -> Result<stellar_rpc_client::SimulateTransactionResponse, Box<dyn std::error::Error>> {
         Ok(self.provider.simulate_transaction(tx_envelope).await?)
     }

--- a/crates/soroban-test-helpers-usage/src/lib.rs
+++ b/crates/soroban-test-helpers-usage/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, symbol_short, vec, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{Address, Env, String, Symbol, Vec, contract, contractimpl, symbol_short, vec};
 
 #[contract]
 pub struct Token;

--- a/crates/soroban-test-helpers-usage/src/test.rs
+++ b/crates/soroban-test-helpers-usage/src/test.rs
@@ -1,8 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as AddressTrait, Address, vec, Env};
-
+use soroban_sdk::{Address, Env, testutils::Address as AddressTrait, vec};
 
 // Default test implementation.
 #[test]
@@ -13,31 +12,17 @@ fn test() {
 
     let contract_id = env.register_contract(None, Token);
     let client = TokenClient::new(&env, &contract_id);
-  
+
     let words = client.send(&alice, &bob);
-    assert_eq!(
-        words,
-        vec![
-            &env,
-            alice.to_string(),
-            bob.to_string(),
-        ]
-    );
+    assert_eq!(words, vec![&env, alice.to_string(), bob.to_string(),]);
 }
 
 // Test implementation using injected arguments.
 #[soroban_test_helpers::test]
 fn test_injected_args(e: Env, alice: Address, bob: Address) {
-  let contract_id = e.register_contract(None, Token);
-  let client = TokenClient::new(&e, &contract_id);
+    let contract_id = e.register_contract(None, Token);
+    let client = TokenClient::new(&e, &contract_id);
 
-  let words = client.send(&alice, &bob);
-  assert_eq!(
-      words,
-      vec![
-          &e,
-          alice.to_string(),
-          bob.to_string(),
-      ]
-  );
+    let words = client.send(&alice, &bob);
+    assert_eq!(words, vec![&e, alice.to_string(), bob.to_string(),]);
 }


### PR DESCRIPTION
## Context:
This change applies Rust's automatic formatting tool, rustfmt, to ensure consistent code style across the repository.

## This Change:

- Reformats all Rust files using rustfmt
- No functional changes, only style updates

## Test Plan:
Run the following command to ensure formatting compliance:
```sh
cargo fmt --all -- --check
```