### PR TITLE
docs: add repository fork link in contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ An example crate demonstrating how to use the `soroban-test-helpers` library for
 
 We welcome contributions from the community! Here's how you can get involved:
 
-1. Fork the repository
+1. [Fork the repository](https://github.com/OpenZeppelin/soroban-helpers/fork)
 2. Create your feature branch
 3. Commit your changes
 4. Push to the branch

--- a/crates/soroban-rs/README.md
+++ b/crates/soroban-rs/README.md
@@ -77,7 +77,7 @@ The library uses a custom error type `SorobanHelperError` to handle various erro
 
 We welcome contributions from the community! Here's how you can get involved:
 
-1. Fork the repository
+1. [Fork the repository](https://github.com/OpenZeppelin/soroban-helpers/fork)
 2. Create your feature branch
 3. Commit your changes
 4. Push to the branch

--- a/crates/soroban-test-helpers/README.md
+++ b/crates/soroban-test-helpers/README.md
@@ -62,7 +62,7 @@ This significantly reduces the amount of boilerplate code in your tests.
 
 We welcome contributions from the community! Here's how you can get involved:
 
-1. Fork the repository
+1. [Fork the repository](https://github.com/OpenZeppelin/soroban-helpers/fork)
 2. Create your feature branch
 3. Commit your changes
 4. Push to the branch


### PR DESCRIPTION
# Summary
- Updated contribution guide in multiple `README.md` files.
- Added a direct link to fork the repository for easier access.

