### PR TITLE
Fix macro bug on unit return value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,7 +2263,9 @@ version = "0.2.4"
 dependencies = [
  "proc-macro2",
  "quote",
+ "soroban-rs",
  "syn 2.0.106",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/soroban-rs-macros/Cargo.toml
+++ b/crates/soroban-rs-macros/Cargo.toml
@@ -17,3 +17,7 @@ proc-macro = true
 syn.workspace = true
 quote.workspace = true
 proc-macro2.workspace = true
+
+[dev-dependencies]
+soroban-rs.workspace = true
+tokio.workspace = true

--- a/crates/soroban-rs-macros/src/lib.rs
+++ b/crates/soroban-rs-macros/src/lib.rs
@@ -36,7 +36,7 @@
 //! ```
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, File, FnArg, Item, ReturnType};
+use syn::{parse_macro_input, File, FnArg, Item};
 
 /// A procedural macro for generating Soroban contract client code.
 ///
@@ -158,12 +158,11 @@ pub fn soroban(input: TokenStream) -> TokenStream {
             })
             .collect::<Vec<_>>();
 
-        // Transform return type to ScVal
-        let transformed_output = match &method.sig.output {
-            ReturnType::Default => quote! {},
-            ReturnType::Type(_, _) => {
-                quote! { -> Result<soroban_rs::SorobanTransactionResponse, soroban_rs::SorobanHelperError>  }
-            }
+        // Generated methods always return the result of `contract.invoke(...).await`, which
+        // is `Result<SorobanTransactionResponse, SorobanHelperError>` — regardless of whether
+        // the source contract method returns a value or unit.
+        let transformed_output = quote! {
+            -> Result<soroban_rs::SorobanTransactionResponse, soroban_rs::SorobanHelperError>
         };
 
         Some(quote! {

--- a/crates/soroban-rs-macros/tests/unit_return.rs
+++ b/crates/soroban-rs-macros/tests/unit_return.rs
@@ -1,0 +1,72 @@
+//! Regression test: the `soroban!` macro must emit a `Result<SorobanTransactionResponse,
+//! SorobanHelperError>` return type for every generated client method, even when the source
+//! contract method returns unit (`()`).
+//!
+//! The generated body is always `self.contract.invoke(...).await`, which yields
+//! `Result<SorobanTransactionResponse, SorobanHelperError>`. If the macro emits an empty
+//! return type for unit-returning source methods, the compiler rejects the expansion with
+//! E0308: `expected (), found Result<...>`.
+
+use soroban_rs_macros::soroban;
+
+soroban!(
+    r#"
+    pub struct UnitReturn;
+
+    impl UnitReturn {
+        pub fn no_return(env: &Env) {
+            // Source returns (). Generated client method must still return
+            // Result<SorobanTransactionResponse, SorobanHelperError>.
+        }
+
+        pub fn no_return_with_args(env: &Env, a: u32, b: u32) {
+            // Same, with arguments.
+        }
+
+        pub fn with_return(env: &Env) -> u32 {
+            // Control case: already works today.
+            0
+        }
+    }
+"#
+);
+
+#[test]
+fn generated_unit_return_method_returns_result() {
+    // Compile-only assertion: if the macro regresses, this file fails to build with E0308.
+    // We additionally pin the generated signature by taking a function pointer whose type
+    // mentions the expected `Result<_, _>` return.
+    fn _assert_signatures(client: &mut UnitReturnClient) {
+        let _: &mut dyn FnMut(
+            &mut UnitReturnClient,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                    Output = Result<
+                        soroban_rs::SorobanTransactionResponse,
+                        soroban_rs::SorobanHelperError,
+                    >,
+                >,
+            >,
+        > = &mut |c| Box::pin(c.no_return());
+
+        let _: &mut dyn FnMut(
+            &mut UnitReturnClient,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                    Output = Result<
+                        soroban_rs::SorobanTransactionResponse,
+                        soroban_rs::SorobanHelperError,
+                    >,
+                >,
+            >,
+        > = &mut |c| {
+            let a = soroban_rs::xdr::ScVal::U32(1);
+            let b = soroban_rs::xdr::ScVal::U32(2);
+            Box::pin(c.no_return_with_args(a, b))
+        };
+
+        let _ = client;
+    }
+}

--- a/crates/soroban-rs-macros/tests/unit_return.rs
+++ b/crates/soroban-rs-macros/tests/unit_return.rs
@@ -24,49 +24,31 @@ soroban!(
         }
 
         pub fn with_return(env: &Env) -> u32 {
-            // Control case: already works today.
+            // Control case: already worked before the fix.
             0
         }
     }
 "#
 );
 
+// Compile-only: pin the generated return types. If the macro regresses to emitting no return
+// type for unit-returning source methods, this function fails to type-check.
+#[allow(dead_code)]
+async fn _assert_signatures(client: &mut UnitReturnClient) {
+    let _: Result<soroban_rs::SorobanTransactionResponse, soroban_rs::SorobanHelperError> =
+        client.no_return().await;
+
+    let a = soroban_rs::xdr::ScVal::U32(1);
+    let b = soroban_rs::xdr::ScVal::U32(2);
+    let _: Result<soroban_rs::SorobanTransactionResponse, soroban_rs::SorobanHelperError> =
+        client.no_return_with_args(a, b).await;
+
+    let _: Result<soroban_rs::SorobanTransactionResponse, soroban_rs::SorobanHelperError> =
+        client.with_return().await;
+}
+
 #[test]
-fn generated_unit_return_method_returns_result() {
-    // Compile-only assertion: if the macro regresses, this file fails to build with E0308.
-    // We additionally pin the generated signature by taking a function pointer whose type
-    // mentions the expected `Result<_, _>` return.
-    fn _assert_signatures(client: &mut UnitReturnClient) {
-        let _: &mut dyn FnMut(
-            &mut UnitReturnClient,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<
-                    Output = Result<
-                        soroban_rs::SorobanTransactionResponse,
-                        soroban_rs::SorobanHelperError,
-                    >,
-                >,
-            >,
-        > = &mut |c| Box::pin(c.no_return());
-
-        let _: &mut dyn FnMut(
-            &mut UnitReturnClient,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<
-                    Output = Result<
-                        soroban_rs::SorobanTransactionResponse,
-                        soroban_rs::SorobanHelperError,
-                    >,
-                >,
-            >,
-        > = &mut |c| {
-            let a = soroban_rs::xdr::ScVal::U32(1);
-            let b = soroban_rs::xdr::ScVal::U32(2);
-            Box::pin(c.no_return_with_args(a, b))
-        };
-
-        let _ = client;
-    }
+fn macro_expansion_compiles_for_unit_return_methods() {
+    // The real assertion is that this file compiles. Having a live test case keeps
+    // `cargo test -p soroban-rs-macros --test unit_return` meaningful.
 }


### PR DESCRIPTION
# Summary

When I have methods on my contract with no return value (implicitly `()`), the use of `soroban!` macro cause a compiler error.

## Testing Process

I added a unit test to demonstrate bug with macro on () return value

Run: `cargo test -p soroban-rs-macros --test unit_return`

This fails in first commit, will pass in the second commit to show it fixes that bug

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.
